### PR TITLE
Fixes a problem with this package writing out incorrect SPSS syntax.

### DIFF
--- a/R/writeForeignCode.R
+++ b/R/writeForeignCode.R
@@ -48,9 +48,7 @@ writeForeignSPSS <- function(df, datafile, codefile, varnames = NULL)
         if(any(lengths > 255L))
             stop("Cannot handle character variables longer than 255")
         lengths <- paste0("(A", lengths, ")")
-        # corrected by PR#15583
-        star <- ifelse(c(TRUE, diff(which(chv) > 1L))," *", " ")
-        dl.varnames[chv] <- paste(star, dl.varnames[chv], lengths)
+        dl.varnames[chv] <- paste(" *", dl.varnames[chv], lengths)
   }
 
     cat("DATA LIST FILE=", adQuote(datafile), " free (\",\")\n",


### PR DESCRIPTION
```
Per page 575 of IBM_SPSS_Statistics_Command_Syntax_Reference.pdf (ftp://public.dhe.ibm.com/software/analytics/spss/documentation/statistics/20.0/en/client/Manuals/IBM_SPSS_Statistics_Command_Syntax_Reference.pdf):
"For freefield data, variables with no specified formats take the default F8.2 format. However, an asterisk (*) must be used to indicate where the default format stops. Otherwise, the program tries to apply the next specified format to every variable before it and issues an error message if the number of formats specified is less than the number of variables."
```
